### PR TITLE
travis: Ensure ghc is found

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,18 @@
----
-  language: haskell
-  sudo: false
-  notifications:
-    email: true
-  ghc:
-    - 7.10
-  install:
-    - cabal install shellcheck
-  script:
-- ./test.sh
+sudo: required
+
+services:
+  - docker
+
+cache:
+  directories:
+  - $HOME/.docker
+
+notifications:
+  email: true
+
+before_install:
+  - pip install -U scikit-ci-addons
+  - ci_addons docker load-pull-save r.j3ss.co/shellcheck
+
+script:
+  - make test


### PR DESCRIPTION
This commit fixes the following error message:

  $ export PATH=${TRAVIS_GHC_ROOT}/$(travis_ghc_find 7.1)/bin:$PATH
  travis_ghc_find: error, no such version 7.1
  travis_ghc_find: using default version