### PR TITLE
aptfile: Fix logic excluding installation of gitk & git-gui on GitHub Actions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
+CI ?= false
 
 .PHONY: all
 all: bin dotdirs dotfiles etc
 
 .PHONY: aptfile
 aptfile:
-	sudo OVERRIDE_HOME=$(HOME) aptfile
+	sudo CI=$(CI) OVERRIDE_HOME=$(HOME) aptfile
 
 .PHONY: usr-local-bin
 usr-local-bin:

--- a/aptfile
+++ b/aptfile
@@ -15,7 +15,7 @@ package "fonts-powerline"
 package "gedit-plugins"
 
 # See https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
-if [[ "$CI" == "false" ]]; then
+if [[ "$CI" != "true" ]]; then
   package "git-gui"
   package "gitk"
 else


### PR DESCRIPTION
This commit integrates changes there were inadvertently omitted while working on 06391ed (ci/test-install: Fix aptfile test ensuring package list is up-to-date)